### PR TITLE
Mark the 'types' dictionary member as required.

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -488,7 +488,7 @@ spec: PSL; urlPrefix: https://publicsuffix.org/list/
     };
 
     dictionary StorageClearOptions {
-      sequence&lt;StorageClearType&gt; types;
+      required sequence&lt;StorageClearType&gt; types;
     };
 
     partial interface StorageManager {


### PR DESCRIPTION
The current spec source causes an IDL compilation error stating that
the 'options' parameter of the clear() method must be marked as optional,
since all members of the StorageClearOptions dictionary are optional.

Instead of marking 'options' as optional, this commit marks 'types'
as a required attribute of StorageClearOptions. This is semantically
correct because Clear-Site-Data without 'types' has no purpose.