### PR TITLE
Add a setuptools upgrade step to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: false
 install:
   - git clone --depth=1 --branch=master https://github.com/tabatkins/bikeshed.git ./bikeshed
   - pip install pygments
+  - pip install -U setuptools
   - pip install --editable ./bikeshed
   - bikeshed update
 script:


### PR DESCRIPTION
Currently, Travis builds end with an error "html5lib requires setuptools
version 18.5 or above; please upgrade before installing (you have 12.0.5)"