### PR TITLE
Fixed typo in name of header.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1680,7 +1680,7 @@ host.</p>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="clear-site-data"><code>Clear-Site-Data</code></dfn> HTTP response header field
   sends a signal to the user agent that it ought to remove all data
   of a certain set of types. The header is represented by the following ABNF <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
-<pre class="abnf">Report-To = <a data-link-type="grammar" href="https://greenbytes.de/tech/webdav/draft-ietf-httpbis-jfv-02.html#rfc.section.2">json-field-value</a>
+<pre class="abnf">Clear-Site-Data = <a data-link-type="grammar" href="https://greenbytes.de/tech/webdav/draft-ietf-httpbis-jfv-02.html#rfc.section.2">json-field-value</a>
             ; See Section 2 of [[HTTP-JFV]], and Section 2 of [[RFC7159]]
 </pre>
     <p>The header’s value is interpreted as an array of JSON objects, as described in


### PR DESCRIPTION
The name of the header field was listed as "Report-To", probably a copy/paste error.