### PR TITLE
Added a cache performance warning.

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -281,6 +281,11 @@ spec: PSL; urlPrefix: https://publicsuffix.org/list/
         </pre>
       </div>
 
+      Note: Caches are typically not organized by origin, but rather by URL and
+      timestamp. This means that in practice, clearing cache by origin might
+      have to be implemented using a linear scan. For large caches, this makes
+      it a prohibitively expensive operation.
+
   :   "<dfn grammar>`cookies`</dfn>"
   ::  The "`cookies`" type indicates that the server wishes to remove cookies
       associated with the <a>origin</a> of a particular <a>response</a>'s


### PR DESCRIPTION
Hi again @mikewest , PTAL at this as well.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/msramek/webappsec-clear-site-data/cache-speed-note.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webappsec-clear-site-data/2e3a2dd...msramek:231d648.html)