### PR TITLE
Migrated the performance demo to appengine.

### DIFF
--- a/performance_demo/README.md
+++ b/performance_demo/README.md
@@ -7,19 +7,13 @@ It consists of
 - server.py, a Python server that serves various resources (an HTML page,
   an SVG image, both potentially with the Set-Cookie and/or Clear-Site-Data
   headers)
-- index.html, a single-page website served by the server that allows users
-  to load multiple resources at the same time, with or without Clear-Site-Data
+- index.html, a single-page website that allows the user to load multiple
+  resources at the same time, with or without Clear-Site-Data
 - README.md - this file
 
-## Setup instructions
+## Deployment
 
-1. Download the `performance_demo/` directory.
-2. Run `python server.py` in that directory.
-3. Navigate to `localhost:8000`. (**NOTE:** Clear-Site-Data only works on
-   `localhost` and `https`. Since `server.py` is HTTP-only, navigating to other
-   hosts than `localhost` will not work.)
-4. Use the controls to load resources which add cookies and storage entries,
-   and presumably will be cached.
-5. Use the controls to load resources with the Clear-Site-Data header.
-6. Observe the deletion performance as many instances of headers are processed
-   at the same time.
+The demo is based on [webapp2](https://webapp2.readthedocs.io/), and can be
+deployed on [Google App Engine](https://cloud.google.com/appengine/).
+
+It is currently deployed [here](https://clear-site-data-demo.appspot.com).

--- a/performance_demo/app.yaml
+++ b/performance_demo/app.yaml
@@ -1,0 +1,11 @@
+runtime: python27
+api_version: 1
+threadsafe: true
+
+handlers:
+- url: /resource?
+  script: server.app
+
+- url: /(index\.html)?([?#].*)?$
+  static_files: index.html
+  upload: index.html


### PR DESCRIPTION
Hi @mikewest ,

I converted the Clear-Site-Data demo from BaseHTTPServer to webapp2, so that it can be deployed on AppEngine. See it live here: http://clear-site-data-demo.appspot.com/

PTAL!