### PR TITLE
Use Purge Service Worker Registrations for storage

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -628,11 +628,7 @@ spec: PSL; urlPrefix: https://publicsuffix.org/list/
 
         1.  [=delete a database|Delete=] |database|.
 
-    4.  For each |registration| in the user agent's set of <a>service worker registrations</a>:
-
-        1.  If |registration|'s <a>scope URL</a>'s [=url/origin=] is |origin|:
-
-            1.  Execute {{ServiceWorkerRegistration/unregister()}} on |registration|.
+    4.  Invoke [=Purge Service Worker Registrations=] with |origin| and true.
 
     5.  For each |appcache| in the user agent's set of [=application caches=]:
 


### PR DESCRIPTION
Clear-Site-Data: "storage" has used Service Workers' unregister() as
Service Workers' had no external algorithm that allows immediate purging
of the service worker registrations. This change calls into Purging
Service Worker Reigstration algorithm defined in Service Workers with
the origin and intention to unclaim the controlled clients when
"storage" directive is specified.

Issue: https://github.com/w3c/webappsec-clear-site-data/issues/54.
Service Workers issue: https://github.com/w3c/ServiceWorker/issues/614.
Service Workers PR: https://github.com/w3c/ServiceWorker/pull/1506.